### PR TITLE
Replace httparty with Net::HTTP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       actionmailbox (>= 6.0.0)
       actionmailer (>= 6.0.0)
       activestorage (>= 6.0.0)
-      httparty (>= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -91,17 +90,12 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    csv (3.3.0)
     date (3.3.4)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.1)
-    httparty (0.22.0)
-      csv
-      mini_mime (>= 1.0.0)
-      multi_xml (>= 0.5.2)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -120,8 +114,6 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.1)
-    multi_xml (0.7.1)
-      bigdecimal (~> 3.1)
     net-imap (0.4.17)
       date
       net-protocol

--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -1,6 +1,6 @@
 require 'action_mailer'
 require 'action_mailbox/engine'
-require 'httparty'
+require 'net/http'
 require 'uri'
 require 'json'
 require 'mailpace-rails/version'
@@ -27,32 +27,32 @@ module Mailpace
       end
 
       check_delivery_params(mail)
-      result = HTTParty.post(
-        'https://app.mailpace.com/api/v1/send',
-        body: {
-          from: address_list(mail.header[:from])&.addresses&.first.to_s,
-          to: address_list(mail.header[:to])&.addresses&.join(','),
-          subject: mail.subject,
-          htmlbody: htmlbody,
-          textbody: textbody,
-          cc: address_list(mail.header[:cc])&.addresses&.join(','),
-          bcc: address_list(mail.header[:bcc])&.addresses&.join(','),
-          replyto: address_list(mail.header[:reply_to])&.addresses&.join(','),
-          inreplyto: mail.header['In-Reply-To'].to_s,
-          references: mail.header['References'].to_s,
-          list_unsubscribe: mail.header['list_unsubscribe'].to_s,
-          attachments: format_attachments(mail.attachments),
-          tags: mail.header['tags'].to_s
-        }.delete_if { |_key, value| value.blank? }.to_json,
-        headers: {
-          'User-Agent' => "MailPace Rails Gem v#{Mailpace::Rails::VERSION}",
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json',
-          'Mailpace-Server-Token' => settings[:api_token]
-        }.tap do |h|
-          h['Idempotency-Key'] = mail.header['idempotency_key'].to_s if mail.header['idempotency_key']
-        end
-      )
+      uri = URI('https://app.mailpace.com/api/v1/send')
+      request = Net::HTTP::Post.new(uri)
+      request['User-Agent'] = "MailPace Rails Gem v#{Mailpace::Rails::VERSION}"
+      request['Accept'] = 'application/json'
+      request['Content-Type'] = 'application/json'
+      request['Mailpace-Server-Token'] = settings[:api_token]
+      request['Idempotency-Key'] = mail.header['idempotency_key'].to_s if mail.header['idempotency_key']
+      request.body = {
+        from: address_list(mail.header[:from])&.addresses&.first.to_s,
+        to: address_list(mail.header[:to])&.addresses&.join(','),
+        subject: mail.subject,
+        htmlbody: htmlbody,
+        textbody: textbody,
+        cc: address_list(mail.header[:cc])&.addresses&.join(','),
+        bcc: address_list(mail.header[:bcc])&.addresses&.join(','),
+        replyto: address_list(mail.header[:reply_to])&.addresses&.join(','),
+        inreplyto: mail.header['In-Reply-To'].to_s,
+        references: mail.header['References'].to_s,
+        list_unsubscribe: mail.header['list_unsubscribe'].to_s,
+        attachments: format_attachments(mail.attachments),
+        tags: mail.header['tags'].to_s
+      }.delete_if { |_key, value| value.blank? }.to_json # This can be replaced with `compact_blank` with Rails 6.1+
+
+      result = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(request)
+      end
 
       handle_response(result)
     end
@@ -72,9 +72,9 @@ module Mailpace
     end
 
     def handle_response(result)
-      return result unless result.code != 200
+      parsed_response = JSON.parse(result.body)
+      return parsed_response unless result.code != '200'
 
-      parsed_response = result.parsed_response
       error_message = join_error_messages(parsed_response)
 
       raise DeliveryError, "MAILPACE Error: #{error_message}" unless error_message.empty?

--- a/mailpace-rails.gemspec
+++ b/mailpace-rails.gemspec
@@ -23,8 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('actionmailbox', ">= 6.0.0")
   spec.add_dependency('activestorage', ">= 6.0.0")
 
-  spec.add_dependency('httparty', '>= 0.18.1')
-
   spec.add_development_dependency "rails", "#{ENV['RAILS_TEST_VERSION'] || '>=7.2.0'}"
-  spec.add_development_dependency "sqlite3", ">=1.4.2"
 end


### PR DESCRIPTION
Since `httparty` is used only once and introduces some more dependencies, removing it has some benefits for end users.

This commit was largely created by Copilot, then modified by me, @okuramasafumi.
It requires manual testing.